### PR TITLE
CircleCi implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/configuration-reference/#executor-job
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           paths:
             - .
 
-    run-tests:
+  run-tests:
     docker:
       - image: ivanopulo/terratest:0.0.3
     steps:
@@ -92,6 +92,9 @@ workflows:
       - apply:
           requires:
             - hold-apply
+      - run-tests:
+          requires:
+            - apply
       - plan-destroy:
           requires:
             - apply

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             mkdir "$TF_VAR_pub_key_path"
             echo "$SSH_PUBLIC_KEY" > "$TF_VAR_pub_key_path"/"$TF_VAR_pub_key_filename"
             terraform init -input=false
-            terraform plan -out tfapply -var-file 01-terraform.tfvars
+            terraform plan -out tfapply -var-file terraform.tfvars
       - persist_to_workspace:
           root: .
           paths:
@@ -61,7 +61,7 @@ jobs:
           name: terraform create destroy plan
           command: |
             cd infrastructure
-            terraform plan -destroy -out tfdestroy -var-file 01-terraform.tfvars
+            terraform plan -destroy -out tfdestroy -var-file terraform.tfvars
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,15 +37,16 @@ jobs:
             - .
 
   run-tests:
+  working_directory: /go/src/terratest
     docker:
       - image: ivanopulo/terratest:0.0.4
     steps:
       - attach_workspace:
-          at: /go/src/terratest
+          at: .
       - run:
           name: terratest
           command: |
-            go test /go/src/terratest/infra_test.go
+            go test infra_test.go
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - run:
           name: terraform
           command: |
+            cd infrastructure
             terraform apply -auto-approve tfapply
       - persist_to_workspace:
           root: .
@@ -44,6 +45,7 @@ jobs:
       - run:
           name: terraform create destroy plan
           command: |
+            cd infrastructure
             terraform plan -destroy -out tfdestroy -var-file 01-terraform.tfvars
       - persist_to_workspace:
           root: .
@@ -59,6 +61,7 @@ jobs:
       - run:
           name: terraform destroy
           command: |
+            cd infrastructure
             terraform apply -auto-approve tfdestroy
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,14 @@ jobs:
 
   run-tests:
     docker:
-      - image: ivanopulo/terratest:0.0.3
+      - image: ivanopulo/terratest:0.0.4
     steps:
       - attach_workspace:
-          at: ./terratest
+          at: .
       - run:
           name: terratest
           command: |
-            go test terratest/infra_test.go
+            go test infra_test.go
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: tfsec tests
           command: |
-            aquasec/tfsec --tfvars-file /src/terraform.tfvars /src/infrastructure
+            --tfvars-file /src/terraform.tfvars /src/infrastructure
 
 
   plan-apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
     steps:
       - attach_workspace:
-          at: .
+          at: ./teratest
       - run:
           name: terraform create destroy plan
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - run:
           name: terratest
           command: |
-            go test infra_test.go
+            go test terratest/infra_test.go
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,9 @@ jobs:
       - run:
           name: terraform init & plan
           command: |
-            echo "$SSH_PUBLIC_KEY" > "$TF_VAR_pub_key_path"
             cd infrastructure
+            mkdir "$TF_VAR_pub_key_path"
+            echo "$SSH_PUBLIC_KEY" > "$TF_VAR_pub_key_path"/"$TF_VAR_pub_key_filename"
             terraform init -input=false
             terraform plan -out tfapply -var-file 01-terraform.tfvars
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: tfsec tests
           command: |
-            tfsec --tfvars-file /src/terraform.tfvars /src/infrastructure
+            tfsec --tfvars-file infrastructure/terraform.tfvars infrastructure
 
 
   plan-apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   run-pre-tests:
     working_directory: /src
     docker:
-      - image: ghcr.io/aquasecurity/tfsec-ci:v1.28.4
+      - image: ivanopulo/tfseq-cicd-git:0.0.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - run:
           name: terraform init & plan
           command: |
+            echo "$SSH_PUBLIC_KEY" > "$TF_VAR_pub_key_path"
             cd infrastructure
             terraform init -input=false
             terraform plan -out tfapply -var-file 01-terraform.tfvars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,86 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/configuration-reference/#executor-job
+  plan-apply:
+    working_directory: /tmp/project
     docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/configuration-reference/#steps
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
     steps:
       - checkout
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: terraform init & plan
+          command: |
+            terraform init -input=false
+            terraform plan -out tfapply -var-file 01-terraform.tfvars
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
 
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/configuration-reference/#workflows
+  apply:
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: terraform
+          command: |
+            terraform apply -auto-approve tfapply
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  plan-destroy:
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: terraform create destroy plan
+          command: |
+            terraform plan -destroy -out tfdestroy -var-file 01-terraform.tfvars
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  destroy:
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: terraform destroy
+          command: |
+            terraform apply -auto-approve tfdestroy
+
+
 workflows:
-  say-hello-workflow:
+  version: 2
+  plan_approve_apply:
     jobs:
-      - say-hello
+      - plan-apply
+      - hold-apply:
+          type: approval
+          requires:
+            - plan-apply
+      - apply:
+          requires:
+            - hold-apply
+      - plan-destroy:
+          requires:
+            - apply
+      - hold-destroy:
+          type: approval
+          requires:
+            - plan-destroy
+      - destroy:
+          requires:
+            - hold-destroy
+
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,21 @@ jobs:
           paths:
             - .
 
+    run-tests:
+    docker:
+      - image: ivanopulo/terratest:0.0.3
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: terratest
+          command: |
+            go test infra_test.go
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
   plan-destroy:
     docker:
       - image: docker.mirror.hashicorp.services/hashicorp/terraform:light

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 jobs:
   plan-apply:
-    working_directory: /tmp/project
+    working_directory: /tmp/project/infrastructure
     docker:
       - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: tfsec tests
           command: |
-            --tfvars-file /src/terraform.tfvars /src/infrastructure
+            tfseq --tfvars-file /src/terraform.tfvars /src/infrastructure
 
 
   plan-apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             - .
 
   run-tests:
-  working_directory: /go/src/terratest
+    working_directory: /go/src/terratest
     docker:
       - image: ivanopulo/terratest:0.0.4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,14 @@ jobs:
       - image: ivanopulo/terratest:0.0.4
     steps:
       - attach_workspace:
-          at: .
+          at: /go/src/terratest
       - run:
           name: terratest
           command: |
+            ls -la /go
+            ls -la /go/src
+            ls -la /go/src/terratest
+            ls -la .
             go test infra_test.go
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: tfsec tests
           command: |
-            tfseq --tfvars-file /src/terraform.tfvars /src/infrastructure
+            tfsec --tfvars-file /src/terraform.tfvars /src/infrastructure
 
 
   plan-apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,18 @@
 version: 2.1
 
 jobs:
+  run-pre-tests:
+    working_directory: /src
+    docker:
+      - image: ghcr.io/aquasecurity/tfsec-ci:v1.28.4
+    steps:
+      - checkout
+      - run:
+          name: tfsec tests
+          command: |
+            aquasec/tfsec --tfvars-file /src/terraform.tfvars /src/infrastructure
+
+
   plan-apply:
     working_directory: /tmp/project
     docker:
@@ -85,7 +97,10 @@ workflows:
   version: 2
   plan_approve_apply:
     jobs:
-      - plan-apply
+      - run-pre-tests
+      - plan-apply:
+          requires:
+            - run-pre-tests
       - hold-apply:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,7 @@ jobs:
       - run:
           name: terratest
           command: |
-            ls -la /go
-            ls -la /go/src
-            ls -la /go/src/terratest
-            ls -la .
-            go test infra_test.go
+            go test /go/src/terratest/infra_test.go
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - image: ivanopulo/terratest:0.0.3
     steps:
       - attach_workspace:
-          at: .
+          at: ./terratest
       - run:
           name: terratest
           command: |
@@ -56,7 +56,7 @@ jobs:
       - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
     steps:
       - attach_workspace:
-          at: ./teratest
+          at: .
       - run:
           name: terraform create destroy plan
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 jobs:
   plan-apply:
-    working_directory: /tmp/project/infrastructure
+    working_directory: /tmp/project
     docker:
       - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
     steps:
@@ -10,6 +10,7 @@ jobs:
       - run:
           name: terraform init & plan
           command: |
+            cd infrastructure
             terraform init -input=false
             terraform plan -out tfapply -var-file 01-terraform.tfvars
       - persist_to_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ crash.*.log
 # password, private keys, and other secrets. These should not be part of version 
 # control as they are data points which are potentially sensitive and subject 
 # to change depending on the environment.
-*.tfvars
-*.tfvars.json
+#*.tfvars
+#*.tfvars.json
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore docker directory
+
+**/docker/*

--- a/infra_test.go
+++ b/infra_test.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"testing"
+	"net/http"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchTfvarsAndOutputs(t *testing.T) {
+	t.Parallel()
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../infrastructure",
+		VarsFiles:    []string{"../infrastructure/terraform.tfvars"},
+	}
+
+	// Read variables from the terraform.tfvars file
+	terraformVars := terraform.ReadVarFiles(t, terraformOptions.VarsFiles)
+	vpcCidr := terraformVars["vpc_cidr"].(string)
+	httpSubnetCidr := terraformVars["network_http"].(map[string]interface{})["cidr"].(string)
+	dbSubnetCidr := terraformVars["network_db"].(map[string]interface{})["cidr"].(string)
+
+
+	// Fetch the VPC CIDR block from Terraform output
+	actualVpcCidr := terraform.Output(t, terraformOptions, "vpc_cidr")
+	actualHttpSubnetCidr := terraform.Output(t, terraformOptions, "http_subnet_cidr")
+	actualDbSubnetCidr := terraform.Output(t, terraformOptions, "db_subnet_cidr")
+
+	// Check if the values match
+	assert.Equal(t, vpcCidr, actualVpcCidr)
+	assert.Equal(t, httpSubnetCidr, actualHttpSubnetCidr)
+	assert.Equal(t, dbSubnetCidr, actualDbSubnetCidr)
+
+
+
+	httpInstanceNames := terraformVars["http_instance_names"].([]interface{})
+	dbInstanceNames := terraformVars["db_instance_names"].([]interface{})
+
+	httpIPs := terraform.OutputMap(t, terraformOptions, "http_ip")
+	dbIPs := terraform.OutputMap(t, terraformOptions, "db_ip")
+
+	// Compare the counts
+	assert.Equal(t, len(httpInstanceNames), len(httpIPs))
+	assert.Equal(t, len(dbInstanceNames), len(dbIPs))
+
+
+	httpPublicIPs := terraform.OutputList(t, terraformOptions, "http_public_ips")
+
+	// Test HTTP connection for each instance
+	for _, ip := range httpPublicIPs {
+		resp, err := http.Get("http://" + ip + "/")
+		defer resp.Body.Close()
+
+		// Check if the HTTP request was successful
+		assert.Nil(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+
+
+	dbPublicIPs := terraform.OutputList(t, terraformOptions, "http_public_ips")
+
+	// Check if the list of DB instance public IP addresses is empty
+	assert.Empty(t, dbPublicIPs)
+}

--- a/infra_test.go
+++ b/infra_test.go
@@ -59,7 +59,7 @@ func TestMatchTfvarsAndOutputs(t *testing.T) {
 	}
 
 
-	dbPublicIPs := terraform.OutputList(t, terraformOptions, "http_public_ips")
+	dbPublicIPs := terraform.OutputList(t, terraformOptions, "db_public_ips")
 
 	// Check if the list of DB instance public IP addresses is empty
 	assert.Empty(t, dbPublicIPs)

--- a/infra_test.go
+++ b/infra_test.go
@@ -11,11 +11,11 @@ func TestInfrastructure(t *testing.T) {
     t.Parallel()
 
     terraformOptions := &terraform.Options{
-        TerraformDir: "../src/infrastructure",
+        TerraformDir: "../terratest/infrastructure",
     }
 
     // Get variables from terraform.tfvars
-    tfvarsFilePath := "../src/infrastructure/terraform.tfvars"
+    tfvarsFilePath := "../terratest/infrastructure/terraform.tfvars"
     vars := map[string]interface{}{
         "http_instance_names": terraform.GetVariableAsListFromVarFile(t, tfvarsFilePath, "http_instance_names"),
         "db_instance_names":   terraform.GetVariableAsListFromVarFile(t, tfvarsFilePath, "db_instance_names"),

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.23.1"
+  hashes = [
+    "h1:s23thJVPJHUdS7ESZHoeMkxNcTeaqWvg2usv8ylFVL4=",
+    "zh:024a188ad3c979a9ec0d7d898aaa90a3867a8839edc8d3543ea6155e6e010064",
+    "zh:05b73a04c58534a7527718ef55040577d5c573ea704e16a813e7d1b18a7f4c26",
+    "zh:13932cdee2fa90f40ebaa783f033752864eb6899129e055511359f8d1ada3710",
+    "zh:3500f5febc7878b4426ef89a16c0096eefd4dd0c5b0d9ba00f9ed54387df5d09",
+    "zh:394a48dea7dfb0ae40e506ccdeb5387829dbb8ab00fb64f41c347a1de092aa00",
+    "zh:51a57f258b3bce2c167b39b6ecf486f72f523da05d4c92adc6b697abe1c5ff1f",
+    "zh:7290488a96d8d10119b431eb08a37407c0812283042a21b69bcc2454eabc08ad",
+    "zh:7545389dbbba624c0ffa72fa376b359b27f484aba02139d37ee5323b589e0939",
+    "zh:92266ac6070809e0c874511ae93097c8b1eddce4c0213e487c5439e89b6ad64d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c3841bd650d6ba471c7159bcdfa35200e5e49c2ea11032c481a33cf7875879d",
+    "zh:bd103c46a16e7f9357e08d6427c316ccc56d203452130eed8e36ede3afa3322c",
+    "zh:cab0a16e320c6ca285a3a51f40c8f46dbaa0712856594819b415b4d8b3e63910",
+    "zh:e8adedcda4d6ff47dcae9c9bb884da26ca448fb6f7436be95ad6a341e4d8094a",
+    "zh:fc23701a3723f50878f440dcdf8768ea96d60a0d7c351aa6dfb912ad832c8384",
+  ]
+}

--- a/infrastructure/00-params.tf
+++ b/infrastructure/00-params.tf
@@ -42,3 +42,8 @@ variable "pub_key_path" {
   type = string
   description = "Specify a path to the public ssh key"
 }
+
+variable "pub_key_filename" {
+  type = string
+  description = "Specify a filename of the public ssh key"
+}

--- a/infrastructure/00-params.tf
+++ b/infrastructure/00-params.tf
@@ -39,11 +39,11 @@ variable "db_instance_names" {
 ### SSH PARAMS
 
 variable "pub_key_path" {
-  type = string
+  type        = string
   description = "Specify a path to the public ssh key"
 }
 
 variable "pub_key_filename" {
-  type = string
+  type        = string
   description = "Specify a filename of the public ssh key"
 }

--- a/infrastructure/00-params.tf
+++ b/infrastructure/00-params.tf
@@ -36,3 +36,9 @@ variable "db_instance_names" {
   default = ["instance-db-1", "instance-db-2", "instance-db-3"]
 }
 
+### SSH PARAMS
+
+variable "pub_key_path" {
+  type = string
+  description = "Specify a path to the public ssh key"
+}

--- a/infrastructure/01-terraform.tfvars
+++ b/infrastructure/01-terraform.tfvars
@@ -1,0 +1,15 @@
+vpc_cidr = "192.168.0.0/16"
+
+network_http = {
+  subnet_name = "subnet_http"
+  cidr        = "192.168.1.0/24"
+}
+
+http_instance_names = ["instance-http-1", "instance-http-2"]
+
+network_db = {
+  subnet_name = "subnet_db"
+  cidr        = "192.168.2.0/24"
+}
+
+db_instance_names = ["instance-db-1", "instance-db-2", "instance-db-3"]

--- a/infrastructure/010-ssh-key.tf
+++ b/infrastructure/010-ssh-key.tf
@@ -3,6 +3,6 @@
 # Create default ssh publique key
 resource "aws_key_pair" "user_key" {
   key_name   = "user-key"
-  public_key = file(var.pub_key_path)
+  public_key = file("${var.pub_key_path}/${var.pub_key_filename}")
 }
 

--- a/infrastructure/010-ssh-key.tf
+++ b/infrastructure/010-ssh-key.tf
@@ -3,6 +3,6 @@
 # Create default ssh publique key
 resource "aws_key_pair" "user_key" {
   key_name   = "user-key"
-  public_key = file("~/.ssh/spacelink.pub")
+  public_key = file(var.pub_key_path)
 }
 

--- a/infrastructure/010-ssh-key.tf
+++ b/infrastructure/010-ssh-key.tf
@@ -3,6 +3,6 @@
 # Create default ssh publique key
 resource "aws_key_pair" "user_key" {
   key_name   = "user-key"
-  public_key = file("${var.pub_key_path}/${var.pub_key_filename}")
+  public_key = file("${var.pub_key_path}${var.pub_key_filename}")
 }
 

--- a/infrastructure/010-ssh-key.tf
+++ b/infrastructure/010-ssh-key.tf
@@ -3,6 +3,6 @@
 # Create default ssh publique key
 resource "aws_key_pair" "user_key" {
   key_name   = "user-key"
-  public_key = file("${var.pub_key_path}${var.pub_key_filename}")
+  public_key = file("${var.pub_key_path}/${var.pub_key_filename}")
 }
 

--- a/infrastructure/010-ssh-key.tf
+++ b/infrastructure/010-ssh-key.tf
@@ -3,6 +3,6 @@
 # Create default ssh publique key
 resource "aws_key_pair" "user_key" {
   key_name   = "user-key"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+  public_key = file("~/.ssh/spacelink.pub")
 }
 

--- a/infrastructure/020-network.tf
+++ b/infrastructure/020-network.tf
@@ -1,6 +1,7 @@
 # Network configuration
 
 # VPC creation
+#tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
 resource "aws_vpc" "terraform" {
   cidr_block           = var.vpc_cidr
   enable_dns_hostnames = true

--- a/infrastructure/030-security-group.tf
+++ b/infrastructure/030-security-group.tf
@@ -1,6 +1,7 @@
 # Security group configuration
 
 # Default administration port
+#tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-ec2-add-description-to-security-group-rule
 resource "aws_security_group" "administration" {
   name        = "administration"
   description = "Allow default administration service"
@@ -35,6 +36,7 @@ resource "aws_security_group" "administration" {
 }
 
 # Open web port
+#tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-ec2-add-description-to-security-group-rule
 resource "aws_security_group" "web" {
   name        = "web"
   description = "Allow web incgress trafic"
@@ -69,6 +71,7 @@ resource "aws_security_group" "web" {
 }
 
 # Open database port
+#tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-ec2-add-description-to-security-group-rule
 resource "aws_security_group" "db" {
   name        = "db"
   description = "Allow db incgress trafic"

--- a/infrastructure/060-instance-http.tf
+++ b/infrastructure/060-instance-http.tf
@@ -1,6 +1,7 @@
 #### INSTANCE HTTP ####
 
 # Create instance
+#tfsec:ignore:aws-ec2-enable-at-rest-encryption tfsec:ignore:aws-ec2-enforce-http-token-imds
 resource "aws_instance" "http" {
   for_each      = var.http_instance_names
   ami           = data.aws_ami.ubuntu.id

--- a/infrastructure/061-instance-db.tf
+++ b/infrastructure/061-instance-db.tf
@@ -1,6 +1,7 @@
 #### INSTANCE DB ####
 
 # Create instance
+#tfsec:ignore:aws-ec2-enable-at-rest-encryption tfsec:ignore:aws-ec2-enforce-http-token-imds
 resource "aws_instance" "db" {
   for_each      = var.db_instance_names
   ami           = data.aws_ami.ubuntu.id

--- a/infrastructure/100-outputs.tf
+++ b/infrastructure/100-outputs.tf
@@ -15,13 +15,21 @@ output "db_ip" {
 }
 
 # Terratest outputs
+output "http_instance_names" {
+  value = [for instance in aws_instance.http : instance.tags.Name]
+}
 
-output "http_public_ips" {
+output "db_instance_names" {
+  value = [for instance in aws_instance.db : instance.tags.Name]
+}
+
+
+output "http_instance_public_ips" {
   value = [for instance in aws_instance.http : instance.public_ip]
 }
 
-output "db_public_ips" {
-  value = [for instance in aws_instance.db : instance.public_ip]
+output "db_instance_public_ips" {
+  value = [for instance in aws_instance.db : instance.public_ip if instance.public_ip != ""]
 }
 
 output "vpc_cidr" {

--- a/infrastructure/100-outputs.tf
+++ b/infrastructure/100-outputs.tf
@@ -20,7 +20,7 @@ output "http_public_ips" {
   value = [for instance in aws_instance.http : instance.public_ip]
 }
 
-output "http_public_ips" {
+output "db_public_ips" {
   value = [for instance in aws_instance.db : instance.public_ip]
 }
 

--- a/infrastructure/100-outputs.tf
+++ b/infrastructure/100-outputs.tf
@@ -13,3 +13,25 @@ output "db_ip" {
     instance.id => instance.private_ip
   }
 }
+
+# Terratest outputs
+
+output "http_public_ips" {
+  value = [for instance in aws_instance.http : instance.public_ip]
+}
+
+output "http_public_ips" {
+  value = [for instance in aws_instance.db : instance.public_ip]
+}
+
+output "vpc_cidr" {
+  value = aws_vpc.terraform.cidr_block
+}
+
+output "http_subnet_cidr" {
+  value = aws_subnet.http.cidr_block
+}
+
+output "db_subnet_cidr" {
+  value = aws_subnet.db.cidr_block
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-  region  = "eu-central-1"
+  region = "eu-central-1"
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,4 +1,4 @@
 provider "aws" {
   profile = "default"
-  region = "eu-central-1"
+  region  = "eu-central-1"
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  profile = "default"
   region  = "eu-central-1"
 }

--- a/infrastructure/terraform.tfvars
+++ b/infrastructure/terraform.tfvars
@@ -13,3 +13,7 @@ network_db = {
 }
 
 db_instance_names = ["instance-db-1", "instance-db-2", "instance-db-3"]
+
+#pub_key_filename = "virt.pub"
+
+#pub_key_path = "/home/vanadium/.ssh/"

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -1,4 +1,8 @@
-
 terraform {
   required_version = ">= 0.12"
+  backend "s3" {
+    bucket = "syndicate-tfstate"
+    key    = "terraform/state"
+    region = "eu-central-1"
+  }
 }


### PR DESCRIPTION
# Pull Request Description

## Changes Made

This pull request introduces a CircleCI workflow for our infrastructure project. The workflow includes pre-tests, Terraform plan and apply stages, testing with Terratest, and destroy plan and execution stages. It leverages a combination of Docker images, Terraform, and Terratest to streamline the CI/CD process.

## Workflow Overview

### 1. Pre-Tests (`run-pre-tests`):
- Uses the `ivanopulo/tfsec-cicd-git` Docker image for tfsec tests.
- Checks the Terraform code in the `infrastructure` directory using the `tfsec` tool.

### 2. Terraform Plan and Apply (`plan-apply` and `apply`):
- Initializes Terraform, creates an SSH key, and plans the infrastructure changes.
- Requires manual approval (`hold-apply`) before applying the changes.

### 3. Terratest (`run-tests`):
- Tests the infrastructure changes using Terratest.
- Ensures the applied changes meet the expected outcomes.

### 4. Terraform Destroy Plan and Execute (`plan-destroy` and `destroy`):
- Plans the destruction of the infrastructure.
- Requires manual approval (`hold-destroy`) before executing the destroy.

## How to Review

1. **Pre-Tests:**
   - Ensure `tfsec` tests pass.

2. **Plan and Apply:**
   - Verify the Terraform plan is as expected.
   - Confirm the infrastructure changes are accurate.
   - Manually approve the changes to proceed with the apply.

3. **Terratest:**
   - Confirm that Terratest validates the applied changes successfully.

4. **Plan and Destroy:**
   - Ensure the Terraform destroy plan aligns with expectations.
   - Manually approve the destruction of infrastructure.

## Additional Notes

- The workflow is designed to enhance the reliability and safety of infrastructure changes.
- The manual approval steps (`hold-apply` and `hold-destroy`) provide control over applying and destroying infrastructure.

